### PR TITLE
Revert "Trigger docker-jenkins-mylonelybear after release"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,5 @@ if (env.BRANCH_NAME == 'master') {
         construi 'release'
     }
   }
-
-  build job: '../docker-jenkins-mylonelybear/master', wait: false
 }
 


### PR DESCRIPTION
Reverts lstephen/docker-jenkins#11

We don't want to auto-trigger, because docker-jenkins-mylonleybear doesn't auto update to the latest version
